### PR TITLE
fix display wrong number of result when filter by duration

### DIFF
--- a/be/app/controllers/api/v1/videos.rb
+++ b/be/app/controllers/api/v1/videos.rb
@@ -38,9 +38,8 @@ module API
         end
         post "/search/:page/:per", root: :videos do
           results = []
-          page = params[:page].to_i
-          per = params[:per].to_i
 
+          #Calculate min max duration
           if params[:duration].present?
             min_duration = Settings.filter.duration[params[:duration]].start * 60
             max_duration = Settings.filter.duration[params[:duration]].end * 60
@@ -49,39 +48,42 @@ module API
             max_duration = ""
           end
 
+          #Chossing search operator
           search_operator = params[:search_operator].blank? ? "and" : params[:search_operator]
           
+          #Query sequences from elastic search
           sequences = Sequence.search params[:content], 
                                       operator: search_operator,
                                       fields: [:result],
                                       highlight: { tag: "<strong class='highlight'>" }
          
-          start_record = page * per + 1
-          end_record = (page + 1 ) * per
-          total_video = sequences.each.pluck(:video_id).uniq.length
-          video_ids = sequences.each.pluck(:video_id).uniq[start_record..end_record]
+          #Filter videos
+          video_ids = sequences.each.pluck(:video_id)
           videos = Video.with_ids(video_ids)
                         .with_duration(min_duration, max_duration)
-          if params[:code]
-            videos.unshift Video.find_by code: params[:code]
-          end
+                        .page(params[:page])
+                        .per params[:per]
+
+          total_sequences = 0
           videos.each do |video|
+            video_sequences = sequences.with_highlights
+                                       .map { |s| { id: s[0].id,
+                                                    result: s[1][:result], 
+                                                    start_at: s[0].start_at, 
+                                                    end_at: s[0].end_at} if s[0].video_id.eql? video.id }
+                                       .compact
+            total_sequences += video_sequences.length
             result = {
               video: video,
-              sequences: sequences.with_highlights
-                                  .map { |s| { id: s[0].id,
-                                               result: s[1][:result], 
-                                               start_at: s[0].start_at, 
-                                               end_at: s[0].end_at} if s[0].video_id.eql? video.id }
-                                  .compact
+              sequences: video_sequences
             }
             results.push result
           end
-          
+
           {
             result: results,
-            total: total_video,
-            total_sequences: sequences.total_count,
+            total: videos.total_count,
+            total_sequences: total_sequences,
             time: sequences.took
           }
         end


### PR DESCRIPTION
Nguyên nhân: Do không tính lại số sequences và video theo filter 
Khắc phục: Chuyển về luôn tính theo kết quả sau khi filer (kết quả sau cùng)